### PR TITLE
Migrate project to use uv instead of pip/venv

### DIFF
--- a/flask-app/.gitignore
+++ b/flask-app/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 .Python
 env/
 venv/
+.venv/
 ENV/
 build/
 develop-eggs/
@@ -22,6 +23,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+uv.lock
 
 # Flask
 instance/

--- a/flask-app/README.md
+++ b/flask-app/README.md
@@ -14,6 +14,7 @@ A lightweight, fast personal portfolio and bookshelf website built with Flask, B
 ## Tech Stack
 
 - **Backend**: Flask 3.0 with Python 3.11+
+- **Package Manager**: [uv](https://github.com/astral-sh/uv) - Fast Python package installer and resolver
 - **Database**: SQLite (file-based, portable)
 - **Frontend**: Bootstrap 5.3, vanilla JavaScript
 - **Authentication**: Flask-Login with werkzeug password hashing
@@ -21,21 +22,25 @@ A lightweight, fast personal portfolio and bookshelf website built with Flask, B
 
 ## Quick Start
 
-### 1. Setup Virtual Environment
+### 1. Install Dependencies
+
+First, ensure you have [uv](https://github.com/astral-sh/uv) installed:
+
+```bash
+# Install uv (if not already installed)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Then install project dependencies:
 
 ```bash
 cd flask-app
-python3 -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
+uv sync
 ```
 
-### 2. Install Dependencies
+This will create a virtual environment and install all dependencies automatically.
 
-```bash
-pip install -r requirements.txt
-```
-
-### 3. Configure Environment
+### 2. Configure Environment
 
 Copy `.env.example` to `.env` and update values:
 
@@ -52,20 +57,20 @@ ADMIN_USERNAME=your-username
 ADMIN_PASSWORD=your-password
 ```
 
-### 4. Initialize Database
+### 3. Initialize Database
 
 ```bash
 # Create database with sample data
-python migrations/import_books.py --sample
+uv run python migrations/import_books.py --sample
 
 # Or import from JSON
-python migrations/import_books.py --json books_export.json
+uv run python migrations/import_books.py --json books_export.json
 ```
 
-### 5. Run the Application
+### 4. Run the Application
 
 ```bash
-python app.py
+uv run python app.py
 ```
 
 Visit http://localhost:5001
@@ -117,16 +122,17 @@ flask-app/
 ```bash
 # Install dependencies
 sudo apt update
-sudo apt install python3-pip python3-venv nginx
+sudo apt install nginx
+
+# Install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Clone repository
 git clone <repo-url>
 cd personal-site/flask-app
 
-# Setup virtual environment
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
+# Install dependencies with uv
+uv sync
 ```
 
 ### 2. Configure Gunicorn
@@ -141,8 +147,8 @@ After=network.target
 [Service]
 User=www-data
 WorkingDirectory=/var/www/personal-site/flask-app
-Environment="PATH=/var/www/personal-site/flask-app/venv/bin"
-ExecStart=/var/www/personal-site/flask-app/venv/bin/gunicorn --workers 2 --bind 127.0.0.1:8000 app:create_app()
+Environment="PATH=/var/www/personal-site/flask-app/.venv/bin"
+ExecStart=/var/www/personal-site/flask-app/.venv/bin/gunicorn --workers 2 --bind 127.0.0.1:8000 app:create_app()
 
 [Install]
 WantedBy=multi-user.target
@@ -183,7 +189,13 @@ sudo systemctl restart nginx
 ### 5. SSL with Let's Encrypt
 
 ```bash
-sudo apt install certbot python3-certbot-nginx
+# Install certbot using uv (recommended) or system package manager
+uv tool install certbot
+uv tool install certbot-nginx
+
+# Or use system packages
+# sudo apt install certbot python3-certbot-nginx
+
 sudo certbot --nginx -d yourdomain.com
 ```
 

--- a/flask-app/pyproject.toml
+++ b/flask-app/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "personal-site"
+version = "1.0.0"
+description = "Clay Coffman Personal Site - Flask Version"
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [
+    {name = "Clay Coffman", email = "claymcoffman@gmail.com"}
+]
+dependencies = [
+    "Flask==3.0.0",
+    "Flask-SQLAlchemy==3.1.1",
+    "Flask-Login==0.6.3",
+    "python-dotenv==1.0.0",
+    "Werkzeug==3.0.1",
+    "gunicorn==21.2.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv]
+dev-dependencies = []

--- a/flask-app/requirements.txt
+++ b/flask-app/requirements.txt
@@ -1,6 +1,0 @@
-Flask==3.0.0
-Flask-SQLAlchemy==3.1.1
-Flask-Login==0.6.3
-python-dotenv==1.0.0
-Werkzeug==3.0.1
-gunicorn==21.2.0


### PR DESCRIPTION
- Add pyproject.toml for modern Python packaging with uv
- Update .gitignore to include .venv and uv.lock
- Replace all pip/venv commands with uv equivalents in README
- Remove requirements.txt in favor of pyproject.toml
- Update deployment instructions to use uv