### PR TITLE
feat: replace photos placeholders with Immich → R2 sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,9 @@ npm run dev           # dev server on :4321 (regenerates sprite first)
 npm run build         # static output in dist/
 npm run preview       # serve dist/ locally
 npm run build:icons   # rebuild public/sprite.svg from icons/
-npm run sync-books    # populate src/data/books.json + public/covers/ from Calibre
+npm run sync-books    # populate src/data/books.json + public/covers/ from Hardcover
+npm run sync-highlights  # populate src/data/highlights.json from Readwise
+npm run sync-photos   # populate src/data/photos.json, mirror assets to R2
 ```
 
 ## Bookshelf data flow
@@ -45,6 +47,18 @@ On the server (`cloud-hil-1`), the script runs daily via
 at `/opt/personal-site`; push auth is a per-repo SSH deploy key at
 `/root/.ssh/personal_site_deploy` (write access) used via the
 `github-personal-site` Host alias in `/root/.ssh/config`.
+
+## Photos data flow
+
+The `/photos` page reads `src/data/photos.json`. Asset bytes are *not* committed —
+they live in R2 bucket `personal-site-photos`, served at `https://media.about-clay.com`.
+`scripts/sync-photos.mjs` fetches a curated Immich album (by UUID), mirrors new
+web-sized JPEGs to R2 via `rclone rcat`, orphan-cleans R2 objects no longer in the
+album, and writes the metadata JSON.
+
+Env vars on cloud-hil-1: `IMMICH_API_KEY`, `IMMICH_API_URL`, `IMMICH_ALBUM_ID`,
+`R2_PHOTOS_REMOTE`, `R2_PHOTOS_PUBLIC_URL`. Runs daily via
+`personal-site-sync-photos.timer`.
 
 ### Adding a new dynamic content source
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,32 +2,6 @@
 
 Ongoing work tracked in the repo. For closed items, check `git log`.
 
-## Photos sync (blocked on prerequisites)
-
-Goal: daily sync from Immich → R2 → `src/data/photos.json`, same systemd
-timer pattern as books / highlights. Per-photo asset goes to R2 (not git)
-to keep the repo small.
-
-Prereqs needed before `scripts/sync-photos.mjs` can be written:
-
-- [ ] **Immich API key + URL.** Generate at Immich → Account → API Keys.
-  Add `IMMICH_API_KEY` and `IMMICH_API_URL` to `/root/.secrets/tokens.sh`
-  on cloud-hil-1.
-- [ ] **R2 bucket + custom domain.** Create a public bucket (e.g.
-  `personal-site-photos`) and attach a custom domain (e.g.
-  `photos.about-clay.com`) via the Cloudflare dashboard. Bucket creation
-  can be done via rclone; the custom-domain step requires the dashboard.
-- [ ] **Opt-in filter.** Decide which Immich album or tag marks a photo
-  as publishable — suggested: album literally named `publish`, mirroring
-  the Readwise `publish` tag pattern.
-- [ ] **Consuming page.** Confirm whether the R5 redesign already has a
-  photos page/component or whether one needs to be created. Current
-  `src/data/photos.ts` contains hardcoded placeholders.
-
-Once prereqs are ready, implementation follows the existing
-`scripts/sync-highlights.mjs` shape and delegates git ops to
-`scripts/lib/git-sync.mjs`.
-
 ## Kuma heartbeat observability (optional)
 
 Add `KUMA_PUSH_SYNC_BOOKS` / `KUMA_PUSH_SYNC_HIGHLIGHTS` /

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:icons": "node scripts/build-icons.mjs",
     "sync-books": "node scripts/sync-books.mjs",
     "sync-highlights": "node scripts/sync-highlights.mjs",
+    "sync-photos": "node scripts/sync-photos.mjs",
     "sync-cwa-to-hardcover": "node scripts/sync-cwa-to-hardcover.mjs",
     "import-physical-books": "node scripts/import-physical-books.mjs"
   },

--- a/scripts/sync-photos.mjs
+++ b/scripts/sync-photos.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Syncs photos from a specific Immich album into src/data/photos.json.
+ * Asset bytes are mirrored to an R2 bucket (served at R2_PHOTOS_PUBLIC_URL);
+ * only the JSON metadata is committed. Mirrors the flow of sync-books.mjs.
+ *
+ * Flags:
+ *   --dry-run    Write photos.json locally; skip R2 uploads and git.
+ *   --no-push    Commit but do not push.
+ *
+ * Env (required):
+ *   IMMICH_API_KEY, IMMICH_API_URL, IMMICH_ALBUM_ID
+ *   R2_PHOTOS_REMOTE       e.g. r2-photos:personal-site-photos
+ *   R2_PHOTOS_PUBLIC_URL   e.g. https://media.about-clay.com
+ * Env (optional):
+ *   SYNC_BRANCH            git branch (default: main)
+ *   KUMA_PUSH_SYNC_PHOTOS  heartbeat URL
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import {
+  parseFlags,
+  prepareBranch,
+  commitAndPush,
+  pingKuma,
+} from "./lib/git-sync.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..");
+
+const { dryRun: DRY_RUN, noPush: NO_PUSH } = parseFlags(process.argv);
+const BRANCH = process.env.SYNC_BRANCH || "main";
+
+const BOT_NAME = "immich-sync[bot]";
+const BOT_EMAIL = "noreply@about-clay.com";
+
+const {
+  IMMICH_API_KEY,
+  IMMICH_API_URL,
+  IMMICH_ALBUM_ID,
+  R2_PHOTOS_REMOTE,
+  R2_PHOTOS_PUBLIC_URL,
+} = process.env;
+
+for (const [name, value] of Object.entries({
+  IMMICH_API_KEY,
+  IMMICH_API_URL,
+  IMMICH_ALBUM_ID,
+  R2_PHOTOS_REMOTE,
+  R2_PHOTOS_PUBLIC_URL,
+})) {
+  if (!value) {
+    console.error(`error: ${name} is required`);
+    process.exit(1);
+  }
+}
+
+const IMMICH_BASE = IMMICH_API_URL.replace(/\/$/, "");
+const R2_PHOTOS_PATH = `${R2_PHOTOS_REMOTE}/photos`;
+const PUBLIC_BASE = `${R2_PHOTOS_PUBLIC_URL.replace(/\/$/, "")}/photos`;
+
+async function fetchAlbum() {
+  const url = `${IMMICH_BASE}/api/albums/${IMMICH_ALBUM_ID}`;
+  const res = await fetch(url, {
+    headers: { "x-api-key": IMMICH_API_KEY, Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `immich album fetch failed: ${res.status} ${await res.text()}`,
+    );
+  }
+  return res.json();
+}
+
+function listR2Photos() {
+  const res = spawnSync(
+    "rclone",
+    ["lsf", "--files-only", `${R2_PHOTOS_PATH}/`],
+    { encoding: "utf-8" },
+  );
+  const err = (res.stderr || "").trim();
+  if (res.status !== 0) {
+    if (/directory not found|does not exist|404/i.test(err)) return new Set();
+    throw new Error(`rclone lsf failed: ${err || res.stdout}`);
+  }
+  return new Set(
+    res.stdout.split("\n").map((l) => l.trim()).filter(Boolean),
+  );
+}
+
+async function uploadAssetToR2(assetId, filename) {
+  const url = `${IMMICH_BASE}/api/assets/${assetId}/thumbnail?size=preview`;
+  const res = await fetch(url, { headers: { "x-api-key": IMMICH_API_KEY } });
+  if (!res.ok) {
+    throw new Error(
+      `immich asset fetch ${assetId}: ${res.status} ${await res.text()}`,
+    );
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+  const up = spawnSync(
+    "rclone",
+    ["rcat", `${R2_PHOTOS_PATH}/${filename}`],
+    { input: buf },
+  );
+  if (up.status !== 0) {
+    throw new Error(
+      `rclone rcat ${filename}: ${(up.stderr || "").toString().trim()}`,
+    );
+  }
+}
+
+function deleteFromR2(filename) {
+  const res = spawnSync(
+    "rclone",
+    ["deletefile", `${R2_PHOTOS_PATH}/${filename}`],
+    { encoding: "utf-8" },
+  );
+  if (res.status !== 0) {
+    console.warn(
+      `rclone deletefile ${filename} failed: ${res.stderr || res.stdout}`,
+    );
+  }
+}
+
+function captionFor(asset) {
+  const desc = asset.exifInfo?.description?.trim();
+  if (desc) return desc;
+  const name = asset.originalFileName || asset.fileName || "";
+  const ext = extname(name);
+  return basename(name, ext) || "Untitled";
+}
+
+if (!DRY_RUN) {
+  prepareBranch({ branch: BRANCH, cwd: repoRoot });
+}
+
+console.log(`fetching album ${IMMICH_ALBUM_ID}`);
+const album = await fetchAlbum();
+const albumAssets = (album.assets || []).filter(
+  (a) => String(a.type).toUpperCase() === "IMAGE",
+);
+console.log(
+  `  album "${album.albumName}" → ${albumAssets.length} image assets`,
+);
+
+let existingR2 = new Set();
+if (!DRY_RUN) {
+  existingR2 = listR2Photos();
+  console.log(`  ${existingR2.size} existing photos in R2`);
+}
+
+const photos = [];
+for (const asset of albumAssets) {
+  const width = asset.exifInfo?.exifImageWidth;
+  const height = asset.exifInfo?.exifImageHeight;
+  if (!width || !height) {
+    console.warn(
+      `  skipping ${asset.id} (${asset.originalFileName || ""}): missing dimensions`,
+    );
+    continue;
+  }
+  const filename = `${asset.id}.jpg`;
+  if (!DRY_RUN && !existingR2.has(filename)) {
+    console.log(`  uploading ${filename}`);
+    await uploadAssetToR2(asset.id, filename);
+  }
+  const takenAt =
+    asset.exifInfo?.dateTimeOriginal ??
+    asset.takenAt ??
+    asset.fileCreatedAt ??
+    null;
+  const year = takenAt ? new Date(takenAt).getFullYear() : null;
+  const latitude = asset.exifInfo?.latitude ?? asset.latitude ?? null;
+  const longitude = asset.exifInfo?.longitude ?? asset.longitude ?? null;
+
+  photos.push({
+    id: asset.id,
+    url: `${PUBLIC_BASE}/${filename}`,
+    caption: captionFor(asset),
+    width,
+    height,
+    takenAt,
+    year,
+    ...(latitude != null && longitude != null
+      ? { latitude, longitude }
+      : {}),
+  });
+}
+
+if (!DRY_RUN) {
+  const validIds = new Set(photos.map((p) => `${p.id}.jpg`));
+  for (const existing of existingR2) {
+    if (!validIds.has(existing)) {
+      console.log(`  removing orphan from R2: ${existing}`);
+      deleteFromR2(existing);
+    }
+  }
+}
+
+const dataDir = join(repoRoot, "src", "data");
+mkdirSync(dataDir, { recursive: true });
+const outPath = join(dataDir, "photos.json");
+const newJson = JSON.stringify(photos, null, 2) + "\n";
+const existingJson = existsSync(outPath) ? readFileSync(outPath, "utf-8") : "";
+
+if (newJson !== existingJson) {
+  writeFileSync(outPath, newJson);
+  console.log(`wrote ${photos.length} photos to src/data/photos.json`);
+} else {
+  console.log("no changes to photos.json");
+}
+
+if (DRY_RUN) {
+  console.log("dry-run: skipping git");
+  process.exit(0);
+}
+
+commitAndPush({
+  paths: ["src/data/photos.json"],
+  message: `sync photos: ${photos.length} entries`,
+  botName: BOT_NAME,
+  botEmail: BOT_EMAIL,
+  branch: BRANCH,
+  noPush: NO_PUSH,
+  cwd: repoRoot,
+});
+
+await pingKuma("KUMA_PUSH_SYNC_PHOTOS");
+
+console.log("done");

--- a/src/components/PhotosSection.astro
+++ b/src/components/PhotosSection.astro
@@ -3,7 +3,6 @@ import NumberedSectionHeader from "./NumberedSectionHeader.astro";
 import { photos } from "~/data/photos";
 
 const preview = photos.slice(0, 3);
-const pad4 = (n: number) => String(n).padStart(4, "0");
 ---
 
 <section
@@ -15,21 +14,18 @@ const pad4 = (n: number) => String(n).padStart(4, "0");
     class="grid gap-5 md:grid-cols-3 max-md:grid-cols-2 max-md:gap-2.5"
   >
     {
-      preview.map((ph, i) => (
+      preview.map((ph) => (
         <figure class="m-0">
-          <div
-            class="relative overflow-hidden border border-border bg-background-alt"
-            style={{
-              aspectRatio: ph.aspect,
-              backgroundImage: `linear-gradient(135deg, ${ph.tint}22, ${ph.tint}66)`,
-            }}
-          >
-            <div class="photo-dots absolute inset-0" />
-            <div class="photo-grain absolute inset-0" />
-            <div class="absolute bottom-2 left-2.5 font-mono text-[9px] uppercase tracking-[1px] text-[rgba(245,239,226,0.7)]">
-              IMG_{pad4(i + 1)}
-            </div>
-          </div>
+          <img
+            src={ph.url}
+            alt={ph.caption}
+            width={ph.width}
+            height={ph.height}
+            loading="lazy"
+            decoding="async"
+            class="block w-full border border-border bg-background-alt"
+            style={`aspect-ratio: ${ph.width}/${ph.height}`}
+          />
           <figcaption class="mt-2 font-mono text-[11px] tracking-[0.5px] text-muted">
             {ph.caption}
           </figcaption>
@@ -46,19 +42,3 @@ const pad4 = (n: number) => String(n).padStart(4, "0");
     </a>
   </div>
 </section>
-
-<style>
-  .photo-dots {
-    background-image: radial-gradient(
-      rgba(30, 10, 0, 0.22) 1px,
-      transparent 1.3px
-    );
-    background-size: 3.5px 3.5px;
-    mix-blend-mode: multiply;
-  }
-  .photo-grain {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='240'%3E%3Cfilter id='n'%3E%3CfeTurbulence baseFrequency='0.85' numOctaves='2'/%3E%3C/filter%3E%3Crect width='240' height='240' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
-    mix-blend-mode: multiply;
-    opacity: 0.18;
-  }
-</style>

--- a/src/data/photos.json
+++ b/src/data/photos.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "d1e3292d-b1d9-4d39-82f0-e48d55e0e300",
+    "url": "https://media.about-clay.com/photos/d1e3292d-b1d9-4d39-82f0-e48d55e0e300.jpg",
+    "caption": "20201019-IMG_6019",
+    "width": 2912,
+    "height": 2912,
+    "takenAt": "2020-10-19T08:31:26.37+00:00",
+    "year": 2020
+  }
+]

--- a/src/data/photos.ts
+++ b/src/data/photos.ts
@@ -1,20 +1,15 @@
+import photosData from "./photos.json";
+
 export interface Photo {
+  id: string;
+  url: string;
   caption: string;
-  aspect: string;
-  tint: string;
-  location?: string;
-  year?: number;
+  width: number;
+  height: number;
+  takenAt: string | null;
+  year: number | null;
+  latitude?: number;
+  longitude?: number;
 }
 
-/**
- * Placeholder photo data. Rendered as tinted gradient tiles until real
- * images (and Immich integration with map + geoloc) land.
- */
-export const photos: Photo[] = [
-  { caption: "Wasatch, first snow", aspect: "4/5", tint: "#c2410c", location: "Utah", year: 2026 },
-  { caption: "Sugar House, late afternoon", aspect: "3/2", tint: "#9a3412", location: "Salt Lake City", year: 2026 },
-  { caption: "I-80, westbound", aspect: "3/4", tint: "#7c2d12", location: "Utah", year: 2025 },
-  { caption: "Antelope Island, eastside", aspect: "1/1", tint: "#c2410c", location: "Utah", year: 2025 },
-  { caption: "Little Cottonwood", aspect: "4/3", tint: "#9a3412", location: "Utah", year: 2025 },
-  { caption: "Downtown, State & 200", aspect: "2/3", tint: "#7c2d12", location: "Salt Lake City", year: 2025 },
-];
+export const photos: Photo[] = photosData as Photo[];

--- a/src/pages/photos.astro
+++ b/src/pages/photos.astro
@@ -2,8 +2,6 @@
 import BaseLayout from "~/layouts/BaseLayout.astro";
 import Footer from "~/components/Footer.astro";
 import { photos } from "~/data/photos";
-
-const pad4 = (n: number) => String(n).padStart(4, "0");
 ---
 
 <BaseLayout
@@ -16,33 +14,29 @@ const pad4 = (n: number) => String(n).padStart(4, "0");
       <div
         class="mb-3 font-mono text-[11px] uppercase tracking-[2px] text-accent"
       >
-        {photos.length} images · placeholder set
+        {photos.length} {photos.length === 1 ? "image" : "images"}
       </div>
       <h1 class="text-h1 m-0">Photos</h1>
       <p class="mt-4 max-w-xl text-muted">
-        Currently showing placeholder tiles. Once I wire up Immich I'll swap
-        these for the real archive, with a map view using the geoloc metadata.
+        Photos from Utah and wherever else I'm wandering. Synced from Immich.
       </p>
     </div>
     <div
       class="grid gap-5 md:grid-cols-4 max-md:grid-cols-2 max-md:gap-2.5"
     >
       {
-        photos.map((ph, i) => (
+        photos.map((ph) => (
           <figure class="m-0">
-            <div
-              class="relative overflow-hidden border border-border bg-background-alt"
-              style={{
-                aspectRatio: ph.aspect,
-                backgroundImage: `linear-gradient(135deg, ${ph.tint}22, ${ph.tint}66)`,
-              }}
-            >
-              <div class="photo-dots absolute inset-0" />
-              <div class="photo-grain absolute inset-0" />
-              <div class="absolute bottom-2 left-2.5 font-mono text-[9px] uppercase tracking-[1px] text-[rgba(245,239,226,0.7)]">
-                IMG_{pad4(i + 1)}
-              </div>
-            </div>
+            <img
+              src={ph.url}
+              alt={ph.caption}
+              width={ph.width}
+              height={ph.height}
+              loading="lazy"
+              decoding="async"
+              class="block w-full border border-border bg-background-alt"
+              style={`aspect-ratio: ${ph.width}/${ph.height}`}
+            />
             <figcaption class="mt-2 flex items-baseline justify-between gap-3 font-mono text-[11px] tracking-[0.5px] text-muted">
               <span>{ph.caption}</span>
               {ph.year && <span class="text-foreground-light">{ph.year}</span>}
@@ -54,19 +48,3 @@ const pad4 = (n: number) => String(n).padStart(4, "0");
   </main>
   <Footer />
 </BaseLayout>
-
-<style>
-  .photo-dots {
-    background-image: radial-gradient(
-      rgba(30, 10, 0, 0.22) 1px,
-      transparent 1.3px
-    );
-    background-size: 3.5px 3.5px;
-    mix-blend-mode: multiply;
-  }
-  .photo-grain {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='240'%3E%3Cfilter id='n'%3E%3CfeTurbulence baseFrequency='0.85' numOctaves='2'/%3E%3C/filter%3E%3Crect width='240' height='240' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
-    mix-blend-mode: multiply;
-    opacity: 0.18;
-  }
-</style>


### PR DESCRIPTION
/photos and the homepage Photos section now read from src/data/photos.json and render real <img> tags served out of the personal-site-photos R2 bucket at media.about-clay.com.

scripts/sync-photos.mjs fetches a curated Immich album by UUID, mirrors web-sized JPEGs to R2 via rclone rcat, orphan-cleans removed assets, and writes the metadata JSON. Runs daily via personal-site-sync-photos.timer on cloud-hil-1 (systemd units tracked outside the repo).