### PR TITLE
feat(bookshelf): link covers to Hardcover + card redesign

### DIFF
--- a/scripts/sync-books.mjs
+++ b/scripts/sync-books.mjs
@@ -115,6 +115,7 @@ for (const book of listBooks) {
   books.push({
     id: book.id,
     title: book.title,
+    slug: book.slug || null,
     author: book.author,
     authorSort: book.authorSort,
     tags: book.tags,

--- a/src/components/BookCard.astro
+++ b/src/components/BookCard.astro
@@ -1,5 +1,4 @@
 ---
-import Badge from "./Badge.astro";
 import type { Book } from "~/data/books";
 
 interface Props {
@@ -7,40 +6,62 @@ interface Props {
 }
 
 const { book } = Astro.props;
+
+const href = book.slug ? `https://hardcover.app/books/${book.slug}` : null;
+const alt = book.author ? `${book.title} by ${book.author}` : book.title;
 ---
 
-<div
-  class="overflow-hidden rounded-lg border border-border bg-background shadow-sm"
->
+<figure class="m-0">
   {
-    book.coverUrl ? (
+    href ? (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="no-underline-anim block transition-opacity hover:opacity-85"
+      >
+        {book.coverUrl ? (
+          <img
+            src={book.coverUrl}
+            alt={alt}
+            loading="lazy"
+            decoding="async"
+            class="block aspect-[2/3] w-full border border-border-soft bg-background-alt object-cover"
+          />
+        ) : (
+          <div class="flex aspect-[2/3] w-full items-center justify-center border border-border-soft bg-background-alt p-4 text-center">
+            <span class="font-mono text-[11px] uppercase tracking-[1px] text-muted">
+              No cover
+            </span>
+          </div>
+        )}
+      </a>
+    ) : book.coverUrl ? (
       <img
         src={book.coverUrl}
-        alt={book.title}
-        class="h-[280px] w-full object-cover"
+        alt={alt}
         loading="lazy"
+        decoding="async"
+        class="block aspect-[2/3] w-full border border-border-soft bg-background-alt object-cover"
       />
     ) : (
-      <div class="flex h-[280px] items-center justify-center bg-background-alt">
-        <span class="text-muted/50">No Cover</span>
+      <div class="flex aspect-[2/3] w-full items-center justify-center border border-border-soft bg-background-alt p-4 text-center">
+        <span class="font-mono text-[11px] uppercase tracking-[1px] text-muted">
+          No cover
+        </span>
       </div>
     )
   }
-  <div class="p-4">
-    <h3
-      class="mb-1 text-body-sm font-semibold leading-tight text-foreground"
+  <figcaption class="mt-3">
+    <div
+      class="font-heading text-[17px] leading-[1.2] tracking-[0.5px] text-foreground"
     >
       {book.title}
-    </h3>
-    <p class="mb-2 text-body-2xs text-muted">{book.author}</p>
-    {
-      book.tags.length > 0 && (
-        <div class="flex flex-wrap gap-1">
-          {book.tags.slice(0, 2).map((tag) => (
-            <Badge>{tag}</Badge>
-          ))}
-        </div>
-      )
-    }
-  </div>
-</div>
+    </div>
+    <div
+      class="mt-1 font-mono text-[11px] uppercase tracking-[1px] text-muted"
+    >
+      {book.author}
+    </div>
+  </figcaption>
+</figure>

--- a/src/components/BookGrid.astro
+++ b/src/components/BookGrid.astro
@@ -15,7 +15,7 @@ const { books } = Astro.props;
       <p class="text-muted">No books found. Check back later!</p>
     </div>
   ) : (
-    <div class="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+    <div class="grid grid-cols-2 gap-x-5 gap-y-10 md:grid-cols-3 md:gap-x-6 lg:grid-cols-4">
       {books.map((book) => (
         <BookCard book={book} />
       ))}

--- a/src/data/books.ts
+++ b/src/data/books.ts
@@ -3,6 +3,7 @@ import booksData from "./books.json";
 export interface Book {
   id: number;
   title: string;
+  slug: string | null;
   author: string;
   authorSort: string;
   tags: string[];

--- a/src/pages/bookshelf.astro
+++ b/src/pages/bookshelf.astro
@@ -11,19 +11,17 @@ import { books } from "~/data/books";
 >
   <div data-nav-sentinel aria-hidden="true"></div>
   <main class="px-16 py-16 max-md:px-5 max-md:py-12">
-    <div class="mb-8">
-      <h1 class="text-h2 mb-3">Bookshelf</h1>
-      <p class="text-muted">
-        These are books that I either enjoyed enough to want to read them
-        again, or had a profound impact on my life (or both, in some
-        cases).
-      </p>
-      <p class="text-muted">
-        <em
-          >Curated from my library on <a href="https://hardcover.app/@clayc210"
-            >Hardcover</a
-          >.</em
-        >
+    <div class="mb-12 max-md:mb-8">
+      <div
+        class="mb-3 font-mono text-[11px] uppercase tracking-[2px] text-accent"
+      >
+        {books.length} {books.length === 1 ? "book" : "books"}
+      </div>
+      <h1 class="text-h1 m-0">Bookshelf</h1>
+      <p class="mt-4 max-w-xl text-muted">
+        Books that I either enjoyed enough to want to read them again, or that
+        had a profound impact on my life (or both, in some cases). Curated from
+        my library on <a href="https://hardcover.app/@clayc210">Hardcover</a>.
       </p>
     </div>
     <BookGrid books={books} />


### PR DESCRIPTION
## Summary
- Cover images now link out to `hardcover.app/books/{slug}` when a slug is present on the book record. `sync-books.mjs` writes the slug per book; `Book` type gains `slug: string | null`.
- `BookCard` rebuilt as a `<figure>` with an external-link wrapper around the cover. Title + author restyled to match the site's mono-kicker / serif-heading rhythm. Tag badges removed.
- `BookGrid` tightens horizontal gap, loosens vertical — feels less clumpy at 4-up.
- `/bookshelf` header adopts the same kicker + h1 + lede shape as `/photos`.

Existing `books.json` has no `slug` entries yet, so cards render as non-clickable images until the next `sync-books` run — covers and everything else continue to work normally in the meantime.

## Test plan
- [ ] `npm run build` passes
- [ ] Visit `/bookshelf` in dev — covers render, header hierarchy reads clearly
- [ ] After next `sync-books` run, click a cover → opens the correct Hardcover book page in a new tab
- [ ] Card without a cover still renders the "No cover" placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)