### PR TITLE
feat(photos): sort newest-first + nullable captions

### DIFF
--- a/scripts/sync-photos.mjs
+++ b/scripts/sync-photos.mjs
@@ -23,7 +23,7 @@ import {
   readFileSync,
   writeFileSync,
 } from "node:fs";
-import { basename, dirname, extname, join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   parseFlags,
@@ -97,10 +97,7 @@ async function uploadAssetToR2(assetId, filename) {
 
 function captionFor(asset) {
   const desc = asset.exifInfo?.description?.trim();
-  if (desc) return desc;
-  const name = asset.originalFileName || asset.fileName || "";
-  const ext = extname(name);
-  return basename(name, ext) || "Untitled";
+  return desc || null;
 }
 
 if (!DRY_RUN) {
@@ -159,6 +156,15 @@ for (const asset of albumAssets) {
       : {}),
   });
 }
+
+photos.sort((a, b) => {
+  const at = a.takenAt ? Date.parse(a.takenAt) : null;
+  const bt = b.takenAt ? Date.parse(b.takenAt) : null;
+  if (at == null && bt == null) return 0;
+  if (at == null) return 1;
+  if (bt == null) return -1;
+  return bt - at;
+});
 
 if (!DRY_RUN) {
   const validIds = new Set(photos.map((p) => `${p.id}.jpg`));

--- a/src/components/PhotosSection.astro
+++ b/src/components/PhotosSection.astro
@@ -23,7 +23,7 @@ const preview = photos.slice(0, 3);
         <figure class="m-0">
           <img
             src={ph.url}
-            alt={ph.caption}
+            alt={ph.caption ?? (ph.year ? `Photo from ${ph.year}` : "Photo")}
             width={ph.width}
             height={ph.height}
             loading="lazy"
@@ -31,9 +31,11 @@ const preview = photos.slice(0, 3);
             class="block w-full border border-border bg-background-alt"
             style={`aspect-ratio: ${ph.width}/${ph.height}`}
           />
-          <figcaption class="mt-2 font-mono text-[11px] tracking-[0.5px] text-muted">
-            {ph.caption}
-          </figcaption>
+          {ph.caption && (
+            <figcaption class="mt-2 font-mono text-[11px] tracking-[0.5px] text-muted">
+              {ph.caption}
+            </figcaption>
+          )}
         </figure>
       ))
     }

--- a/src/data/photos.ts
+++ b/src/data/photos.ts
@@ -3,7 +3,7 @@ import photosData from "./photos.json";
 export interface Photo {
   id: string;
   url: string;
-  caption: string;
+  caption: string | null;
   width: number;
   height: number;
   takenAt: string | null;

--- a/src/pages/photos.astro
+++ b/src/pages/photos.astro
@@ -18,18 +18,16 @@ import { photos } from "~/data/photos";
       </div>
       <h1 class="text-h1 m-0">Photos</h1>
       <p class="mt-4 max-w-xl text-muted">
-        Photos from Utah and wherever else I'm wandering. Synced from Immich.
+        Photos from Utah and wherever else I'm wandering.
       </p>
     </div>
-    <div
-      class="grid gap-5 md:grid-cols-4 max-md:grid-cols-2 max-md:gap-2.5"
-    >
+    <div class="grid gap-5 md:grid-cols-4 max-md:grid-cols-2 max-md:gap-2.5">
       {
         photos.map((ph) => (
           <figure class="m-0">
             <img
               src={ph.url}
-              alt={ph.caption}
+              alt={ph.caption ?? (ph.year ? `Photo from ${ph.year}` : "Photo")}
               width={ph.width}
               height={ph.height}
               loading="lazy"
@@ -37,10 +35,12 @@ import { photos } from "~/data/photos";
               class="block w-full border border-border bg-background-alt"
               style={`aspect-ratio: ${ph.width}/${ph.height}`}
             />
-            <figcaption class="mt-2 flex items-baseline justify-between gap-3 font-mono text-[11px] tracking-[0.5px] text-muted">
-              <span>{ph.caption}</span>
-              {ph.year && <span class="text-foreground-light">{ph.year}</span>}
-            </figcaption>
+            {(ph.caption || ph.year) && (
+              <figcaption class="mt-2 flex items-baseline justify-between gap-3 font-mono text-[11px] tracking-[0.5px] text-muted">
+                <span>{ph.caption ?? ""}</span>
+                {ph.year && <span class="text-foreground-light">{ph.year}</span>}
+              </figcaption>
+            )}
           </figure>
         ))
       }


### PR DESCRIPTION
## Summary
- `sync-photos.mjs` no longer invents captions from filenames. If a photo has no EXIF description, `caption` is now `null` instead of `"IMG_1234"`.
- Photos sort newest-first by `takenAt`; assets without a date fall to the end.
- `Photo.caption` is `string | null` everywhere.
- `PhotosSection` and `/photos` skip rendering `<figcaption>` when neither caption nor year is present. `alt` falls back to `"Photo from {year}"` or `"Photo"` when caption is null.

Visual effect: the photos grid now leads with recent work, and photos without a real caption render cleanly with no filename debris underneath.

## Test plan
- [ ] `npm run build` passes
- [ ] `/photos` renders with the most recent photo first
- [ ] Photos without a caption show no figcaption (or just the year)
- [ ] `npm run sync-photos -- --dry-run` on the host produces a photos.json where captions are either a real description or `null` — no filename fallbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)