### PR TITLE
feat(photos): justified flex gallery + drop filename captions

### DIFF
--- a/src/components/PhotosSection.astro
+++ b/src/components/PhotosSection.astro
@@ -9,11 +9,15 @@ const preview = photos.slice(0, 3);
   id="photos"
   class="scroll-mt-8 border-t border-border px-16 py-30 md:min-h-screen max-md:px-5 max-md:py-16"
 >
-  <NumberedSectionHeader num="04" title="Photos" kicker="coming soon" />
+  <NumberedSectionHeader
+    num="04"
+    title="Photos"
+    kicker={`${photos.length} images`}
+  />
   <p
     class="mb-10 max-w-[820px] font-heading text-[1.25rem] leading-[1.5] text-foreground-light font-normal max-md:mb-7 max-md:text-base"
   >
-    Photos from Utah adventures — real ones coming soon. These are placeholders.
+    Photos from Utah and wherever else I'm wandering.
   </p>
   <div
     class="grid gap-5 md:grid-cols-3 max-md:grid-cols-2 max-md:gap-2.5"
@@ -23,7 +27,7 @@ const preview = photos.slice(0, 3);
         <figure class="m-0">
           <img
             src={ph.url}
-            alt={ph.caption ?? (ph.year ? `Photo from ${ph.year}` : "Photo")}
+            alt={ph.year ? `Photo from ${ph.year}` : "Photo"}
             width={ph.width}
             height={ph.height}
             loading="lazy"
@@ -31,11 +35,6 @@ const preview = photos.slice(0, 3);
             class="block w-full border border-border bg-background-alt"
             style={`aspect-ratio: ${ph.width}/${ph.height}`}
           />
-          {ph.caption && (
-            <figcaption class="mt-2 font-mono text-[11px] tracking-[0.5px] text-muted">
-              {ph.caption}
-            </figcaption>
-          )}
         </figure>
       ))
     }

--- a/src/pages/photos.astro
+++ b/src/pages/photos.astro
@@ -21,30 +21,54 @@ import { photos } from "~/data/photos";
         Photos from Utah and wherever else I'm wandering.
       </p>
     </div>
-    <div class="grid gap-5 md:grid-cols-4 max-md:grid-cols-2 max-md:gap-2.5">
+    <div class="photo-gallery">
       {
         photos.map((ph) => (
-          <figure class="m-0">
+          <figure
+            class="photo-item"
+            style={`--aspect: ${ph.width / ph.height};`}
+          >
             <img
               src={ph.url}
-              alt={ph.caption ?? (ph.year ? `Photo from ${ph.year}` : "Photo")}
+              alt={ph.year ? `Photo from ${ph.year}` : "Photo"}
               width={ph.width}
               height={ph.height}
               loading="lazy"
               decoding="async"
-              class="block w-full border border-border bg-background-alt"
-              style={`aspect-ratio: ${ph.width}/${ph.height}`}
             />
-            {(ph.caption || ph.year) && (
-              <figcaption class="mt-2 flex items-baseline justify-between gap-3 font-mono text-[11px] tracking-[0.5px] text-muted">
-                <span>{ph.caption ?? ""}</span>
-                {ph.year && <span class="text-foreground-light">{ph.year}</span>}
-              </figcaption>
-            )}
           </figure>
         ))
       }
     </div>
+
+    <style>
+      .photo-gallery {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      .photo-item {
+        flex-grow: var(--aspect);
+        flex-basis: calc(var(--aspect) * 240px);
+        margin: 0;
+        min-width: 0;
+        background: var(--color-background-alt);
+        border: 1px solid var(--color-border);
+      }
+      .photo-item img {
+        display: block;
+        width: 100%;
+        height: auto;
+      }
+      @media (max-width: 768px) {
+        .photo-gallery {
+          gap: 6px;
+        }
+        .photo-item {
+          flex-basis: calc(var(--aspect) * 160px);
+        }
+      }
+    </style>
   </main>
   <Footer />
 </BaseLayout>


### PR DESCRIPTION
## Summary
- `/photos` switches from a fixed 4-col grid to a **justified-rows layout** using pure CSS flexbox. Each figure gets `flex-grow` and `flex-basis` proportional to its aspect ratio, so portraits end up narrow, landscapes wide, and rows line up at roughly uniform height. No layout library, no resize listener.
- Strip the per-photo caption entirely on `/photos` and on the homepage `PhotosSection`. Every caption in the current `photos.json` is just an EXIF filename (`IMG_8061`, etc.), which is noise. The UI shouldn't render that regardless of what the data says.
- Refresh the homepage Photos section kicker + lede (was "coming soon / real ones coming soon — these are placeholders"). They're live.

Why pure CSS over a library: photos vary from 1148×2041 portraits to 6240×3510 widescreen. The `flex-grow: aspect` pattern gives the Flickr/Unsplash effect for free. `@flickr/justified-layout` was the alternative but requires a resize listener and fixed-width recompute; flex gives us responsive for free.

## Test plan
- [ ] `npm run build` passes (verified locally)
- [ ] `/photos` renders as variable-width rows of roughly equal height
- [ ] No figcaptions render anywhere (neither `/photos` nor homepage preview)
- [ ] Layout reflows cleanly at mobile / tablet / desktop widths
- [ ] Last row may be shorter than full rows — confirm that's acceptable (it's the nature of justified layouts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)