### PR TITLE
feat(bookshelf): denser grid, better covers, CDN transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 # Environment
 .env
 .env.*
+personal-site-sync.env
 
 # Editor
 .vscode/

--- a/scripts/lib/git-sync.mjs
+++ b/scripts/lib/git-sync.mjs
@@ -12,6 +12,7 @@ export function parseFlags(argv) {
   return {
     dryRun: argv.includes("--dry-run"),
     noPush: argv.includes("--no-push"),
+    forceCovers: argv.includes("--force-covers"),
   };
 }
 

--- a/scripts/lib/hardcover.mjs
+++ b/scripts/lib/hardcover.mjs
@@ -282,6 +282,11 @@ export async function addToList({ bookId, listId, editionId = null }) {
 /**
  * Fetch all books in a list, ordered by position. Returns a projection
  * compatible with the site's Book interface (id/title/author/tags/hasCover).
+ *
+ * For covers, pulls the book-level `image` plus all English editions with
+ * images, then picks the largest (by area). The book-level `cached_image` is
+ * often a low-res thumbnail imported from a third-party feed (~98×142), while
+ * editions frequently carry 300×500+ covers uploaded to Hardcover's own CDN.
  */
 export async function getList({ listId }) {
   const data = await gql(
@@ -297,9 +302,19 @@ export async function getList({ listId }) {
           title
           slug
           release_year
-          cached_image
           cached_tags
           cached_contributors
+          image { url width height }
+          editions(
+            limit: 20,
+            order_by: [{users_count: desc_nulls_last}, {id: asc}],
+            where: {
+              image: {url: {_is_null: false}},
+              language_id: {_eq: 1}
+            }
+          ) {
+            image { url width height }
+          }
         }
       }
     }`,
@@ -316,10 +331,26 @@ export async function getList({ listId }) {
       author: authors.join(", "),
       authorSort: authors[0] || "",
       tags: extractGenres(b.cached_tags),
-      imageUrl: b.cached_image?.url || null,
+      imageUrl: pickBestCover(b),
       releaseYear: b.release_year,
     };
   });
+}
+
+function pickBestCover(book) {
+  let bestUrl = null;
+  let bestArea = 0;
+  const consider = (img) => {
+    if (!img?.url || !img.width || !img.height) return;
+    const area = img.width * img.height;
+    if (area > bestArea) {
+      bestUrl = img.url;
+      bestArea = area;
+    }
+  };
+  consider(book.image);
+  for (const ed of book.editions ?? []) consider(ed.image);
+  return bestUrl;
 }
 
 // -- scoring & extraction helpers --

--- a/scripts/sync-books.mjs
+++ b/scripts/sync-books.mjs
@@ -5,8 +5,10 @@
  * R2_PHOTOS_PUBLIC_URL/covers/{id}.jpg; only the metadata JSON is committed.
  *
  * Flags:
- *   --dry-run    Write books.json locally; skip R2 uploads and git.
- *   --no-push    Commit but do not push.
+ *   --dry-run        Write books.json locally; skip R2 uploads and git.
+ *   --no-push        Commit but do not push.
+ *   --force-covers   Re-upload all covers to R2 even if already present
+ *                    (use when the sync logic has changed what source it picks).
  *
  * Env:
  *   HARDCOVER_API_KEY     required; see scripts/lib/hardcover.mjs
@@ -39,7 +41,11 @@ import { findUserList, getList } from "./lib/hardcover.mjs";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, "..");
 
-const { dryRun: DRY_RUN, noPush: NO_PUSH } = parseFlags(process.argv);
+const {
+  dryRun: DRY_RUN,
+  noPush: NO_PUSH,
+  forceCovers: FORCE_COVERS,
+} = parseFlags(process.argv);
 const BRANCH = process.env.SYNC_BRANCH || "main";
 
 const BOT_NAME = "hardcover-sync[bot]";
@@ -101,7 +107,7 @@ for (const book of listBooks) {
   let coverUrl = null;
   if (book.imageUrl) {
     coverUrl = `${PUBLIC_COVERS}/${filename}`;
-    if (!DRY_RUN && !existingR2.has(filename)) {
+    if (!DRY_RUN && (!existingR2.has(filename) || FORCE_COVERS)) {
       console.log(`  uploading cover ${filename}`);
       try {
         const uploaded = await uploadCoverToR2(book.imageUrl, filename);

--- a/src/components/BookCard.astro
+++ b/src/components/BookCard.astro
@@ -66,14 +66,14 @@ const placeholderClass =
       </div>
     )
   }
-  <figcaption class="mt-3">
+  <figcaption class="mt-4">
     <div
-      class="font-heading text-[14px] leading-[1.25] tracking-[0.3px] text-foreground"
+      class="font-heading text-[16px] leading-[1.25] tracking-[0.3px] text-foreground"
     >
       {book.title}
     </div>
     <div
-      class="mt-0.5 font-mono text-[10px] uppercase tracking-[1px] text-muted"
+      class="mt-1.5 font-mono text-[11px] uppercase tracking-[1px] text-muted"
     >
       {book.author}
     </div>

--- a/src/components/BookCard.astro
+++ b/src/components/BookCard.astro
@@ -1,5 +1,6 @@
 ---
 import type { Book } from "~/data/books";
+import { cdnImage, cdnSrcset } from "~/lib/cdnImage";
 
 interface Props {
   book: Book;
@@ -9,6 +10,15 @@ const { book } = Astro.props;
 
 const href = book.slug ? `https://hardcover.app/books/${book.slug}` : null;
 const alt = book.author ? `${book.title} by ${book.author}` : book.title;
+
+const COVER_WIDTHS = [160, 240, 320, 480];
+const COVER_SIZES =
+  "(max-width: 768px) 33vw, (max-width: 1024px) 20vw, 16vw";
+
+const imgClass =
+  "block aspect-[2/3] w-full border border-border-soft bg-background-alt object-cover";
+const placeholderClass =
+  "flex aspect-[2/3] w-full items-center justify-center border border-border-soft bg-background-alt p-4 text-center";
 ---
 
 <figure class="m-0">
@@ -18,18 +28,20 @@ const alt = book.author ? `${book.title} by ${book.author}` : book.title;
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        class="no-underline-anim block transition-opacity hover:opacity-85"
+        class="no-underline-anim block transition-all duration-200 ease-out hover:-translate-y-0.5 hover:brightness-110 hover:drop-shadow-lg"
       >
         {book.coverUrl ? (
           <img
-            src={book.coverUrl}
+            src={cdnImage(book.coverUrl, { width: 240 })}
+            srcset={cdnSrcset(book.coverUrl, COVER_WIDTHS)}
+            sizes={COVER_SIZES}
             alt={alt}
             loading="lazy"
             decoding="async"
-            class="block aspect-[2/3] w-full border border-border-soft bg-background-alt object-cover"
+            class={imgClass}
           />
         ) : (
-          <div class="flex aspect-[2/3] w-full items-center justify-center border border-border-soft bg-background-alt p-4 text-center">
+          <div class={placeholderClass}>
             <span class="font-mono text-[11px] uppercase tracking-[1px] text-muted">
               No cover
             </span>
@@ -38,14 +50,16 @@ const alt = book.author ? `${book.title} by ${book.author}` : book.title;
       </a>
     ) : book.coverUrl ? (
       <img
-        src={book.coverUrl}
+        src={cdnImage(book.coverUrl, { width: 240 })}
+        srcset={cdnSrcset(book.coverUrl, COVER_WIDTHS)}
+        sizes={COVER_SIZES}
         alt={alt}
         loading="lazy"
         decoding="async"
-        class="block aspect-[2/3] w-full border border-border-soft bg-background-alt object-cover"
+        class={imgClass}
       />
     ) : (
-      <div class="flex aspect-[2/3] w-full items-center justify-center border border-border-soft bg-background-alt p-4 text-center">
+      <div class={placeholderClass}>
         <span class="font-mono text-[11px] uppercase tracking-[1px] text-muted">
           No cover
         </span>
@@ -54,12 +68,12 @@ const alt = book.author ? `${book.title} by ${book.author}` : book.title;
   }
   <figcaption class="mt-3">
     <div
-      class="font-heading text-[17px] leading-[1.2] tracking-[0.5px] text-foreground"
+      class="font-heading text-[14px] leading-[1.25] tracking-[0.3px] text-foreground"
     >
       {book.title}
     </div>
     <div
-      class="mt-1 font-mono text-[11px] uppercase tracking-[1px] text-muted"
+      class="mt-0.5 font-mono text-[10px] uppercase tracking-[1px] text-muted"
     >
       {book.author}
     </div>

--- a/src/components/BookGrid.astro
+++ b/src/components/BookGrid.astro
@@ -15,7 +15,7 @@ const { books } = Astro.props;
       <p class="text-muted">No books found. Check back later!</p>
     </div>
   ) : (
-    <div class="grid grid-cols-3 gap-x-4 gap-y-8 md:grid-cols-5 md:gap-x-5 lg:grid-cols-6 xl:grid-cols-7">
+    <div class="grid grid-cols-3 gap-x-3 gap-y-12 md:grid-cols-5 md:gap-x-4 md:gap-y-14 lg:grid-cols-7 xl:grid-cols-8">
       {books.map((book) => (
         <BookCard book={book} />
       ))}

--- a/src/components/BookGrid.astro
+++ b/src/components/BookGrid.astro
@@ -15,7 +15,7 @@ const { books } = Astro.props;
       <p class="text-muted">No books found. Check back later!</p>
     </div>
   ) : (
-    <div class="grid grid-cols-2 gap-x-5 gap-y-10 md:grid-cols-3 md:gap-x-6 lg:grid-cols-4">
+    <div class="grid grid-cols-3 gap-x-4 gap-y-8 md:grid-cols-5 md:gap-x-5 lg:grid-cols-6 xl:grid-cols-7">
       {books.map((book) => (
         <BookCard book={book} />
       ))}


### PR DESCRIPTION
## Summary

Fixes the blurry-cover complaint and tightens the shelf layout.

**Root cause**: sync-books was pulling Hardcover's `book.cached_image.url`, which for ~half the list is a low-res `/external_data/` thumbnail (98×142). Most books have a much higher-res cover available on a specific edition.

### Sync-side (requires one-time re-sync)

- `scripts/lib/hardcover.mjs` — `getList` now queries book + English editions with images and returns the URL with the largest pixel area. For our 60-book list: 55 jump to ~330×500+, a handful reach 1500×2500px; only "Wherever You Go, There You Are" stays at 98×142 (sole edition on Hardcover).
- `scripts/sync-books.mjs` — new `--force-covers` flag to re-upload all covers to R2 even if present. Regular nightly runs still skip existing.
- `scripts/lib/git-sync.mjs` — parses the new flag.

### Frontend polish

- `BookCard.astro` — uses the shared `cdnImage` / `cdnSrcset` helpers (widths 160/240/320/480) so CF serves AVIF sized to the display. Subtle hover lift + brightness. Tighter caption typography.
- `BookGrid.astro` — 3 / 5 / 7 / 8 cols across mobile / md / lg / xl, with generous row gap.
- `.gitignore` — keep `personal-site-sync.env` out of the repo.

## Deploy sequence

1. Merge this PR to `main`.
2. On `cloud-hil-1`, run the sync once with `--force-covers` so all 60 covers get re-uploaded with higher-res sources:
   ```bash
   npm run sync-books -- --force-covers
   ```
3. In Cloudflare dashboard, purge cache for `https://media.about-clay.com/covers/*` (otherwise CF's transform cache will serve the old 98×142 variants for up to 4h).

## Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] `/bookshelf` renders 3 / 5 / 7 / 8 cols at 375 / 768 / 1024 / 1280 viewports
- [ ] Cover images return as AVIF from `/cdn-cgi/image/width=…,format=auto,quality=82/covers/…`
- [ ] Hover: subtle lift + brightness, click → Hardcover opens in new tab
- [ ] "No cover" placeholder still renders for the 3 books without any image
- [ ] After the post-merge sync + cache purge, covers look sharp at display size

🤖 Generated with [Claude Code](https://claude.com/claude-code)