### PR TITLE
feat(nav): always visible on non-home pages

### DIFF
--- a/src/components/TopNav.astro
+++ b/src/components/TopNav.astro
@@ -6,10 +6,15 @@ const items = [
   { label: "Writing", href: "/blog", section: "writing" },
   { label: "Bookshelf", href: "/bookshelf", section: "books" },
 ];
+
+// Home reveals nav on scroll past the hero (preserves the clean landing
+// aesthetic). Every other page shows it immediately.
+const isHome = Astro.url.pathname === "/";
 ---
 
 <nav
   data-top-nav
+  data-revealed={isHome ? undefined : ""}
   class="top-nav fixed top-0 inset-x-0 z-50 border-b border-border flex items-baseline justify-between font-mono text-xs uppercase tracking-[1.5px] px-16 py-[18px] max-md:px-5 max-md:py-3.5"
 >
   <a
@@ -140,12 +145,8 @@ const items = [
       { rootMargin: "0px 0px 0px 0px", threshold: 0 }
     );
     observer.observe(sentinel);
-  } else if (nav) {
-    // Fallback for pages without a sentinel: reveal after 100px scroll
-    const onScroll = () => setRevealed(window.scrollY > 100);
-    window.addEventListener("scroll", onScroll, { passive: true });
-    onScroll();
   }
+  // Non-home pages have data-revealed set from the server — no script needed.
 
   // Mobile drawer controls
   const openBtn = document.querySelector<HTMLButtonElement>(

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -40,7 +40,6 @@ const formattedUpdatedDate = updatedDate?.toLocaleDateString("en-US", {
   description={description}
   ogImage={heroImage}
 >
-  <div data-nav-sentinel aria-hidden="true"></div>
   <main class="px-16 py-16 max-md:px-5 max-md:py-12">
     <article class="mx-auto max-w-2xl">
       <header class="mb-8">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -13,7 +13,6 @@ const posts = (
   title="Clay Coffman — Blog"
   description="Writing on software, systems, and whatever else I'm thinking about."
 >
-  <div data-nav-sentinel aria-hidden="true"></div>
   <main class="px-16 py-16 max-md:px-5 max-md:py-12">
     <h1 class="text-h2 mb-8">Blog</h1>
     {

--- a/src/pages/bookshelf.astro
+++ b/src/pages/bookshelf.astro
@@ -9,7 +9,6 @@ import { books } from "~/data/books";
   title="Clay Coffman — Bookshelf"
   description="Curated highlights from my book library."
 >
-  <div data-nav-sentinel aria-hidden="true"></div>
   <main class="px-16 py-16 max-md:px-5 max-md:py-12">
     <div class="mb-12 max-md:mb-8">
       <div

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -13,7 +13,6 @@ const education = profileData.education;
   title="Clay Coffman — Experience"
   description="Work history: roles, companies, and what I did there."
 >
-  <div data-nav-sentinel aria-hidden="true"></div>
   <main class="px-16 py-16 max-md:px-5 max-md:py-12">
     <div class="mb-12 max-md:mb-8">
       <div class="mb-3 font-mono text-[11px] uppercase tracking-[2px] text-accent">

--- a/src/pages/photos.astro
+++ b/src/pages/photos.astro
@@ -13,7 +13,6 @@ const GALLERY_SIZES =
   title="Clay Coffman — Photos"
   description="Photos from Utah and wherever else I'm wandering."
 >
-  <div data-nav-sentinel aria-hidden="true"></div>
   <main class="px-16 py-16 max-md:px-5 max-md:py-12">
     <div class="mb-12 max-md:mb-8">
       <div

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -11,7 +11,6 @@ const projects = profileData.projects;
   title="Clay Coffman — Projects"
   description="Things I'm building or have built."
 >
-  <div data-nav-sentinel aria-hidden="true"></div>
   <main class="px-16 py-16 max-md:px-5 max-md:py-12">
     <div class="mb-12 max-md:mb-8">
       <div

--- a/src/pages/subscribe.astro
+++ b/src/pages/subscribe.astro
@@ -8,7 +8,6 @@ import SubscribeForm from "~/components/SubscribeForm.astro";
   title="Subscribe — Clay Coffman"
   description="Get new posts by email. Infrequent, no filler, unsubscribe anytime."
 >
-  <div data-nav-sentinel aria-hidden="true"></div>
   <main class="px-16 py-16 max-md:px-5 max-md:py-12">
     <div class="mb-12 max-md:mb-8">
       <div


### PR DESCRIPTION
## Summary

The scroll-to-reveal nav behavior was intentional on `/` — it keeps the hero landing clean until you scroll past it. But on every other page, the `data-nav-sentinel` was placed at the top of the document, which kept the nav hidden on first paint with no hint that it existed. Users had to scroll to discover they could navigate anywhere.

### What changed

- **`TopNav.astro`** — checks `Astro.url.pathname` and renders with `data-revealed` attribute set *from the server* when not on `/`. That means the nav is visible before any JS runs, with no fade-in flash. On `/`, the IntersectionObserver-driven scroll-reveal still works as before.
- **Sentinel cleanup** — removed the top-of-page `<div data-nav-sentinel>` from `/experience`, `/bookshelf`, `/photos`, `/projects`, `/subscribe`, `/blog`, and `BlogPostLayout`. Only `HeroSection` (homepage) keeps it.

No JS required on non-home pages to show the nav — the server marks it revealed, CSS honors it on first paint.

## Test plan

- [ ] `/` still hides nav on load, reveals after scrolling past the hero
- [ ] `/bookshelf`, `/photos`, `/experience`, `/projects`, `/subscribe`, `/blog`, and any `/blog/:slug` — nav visible on first paint, no FOUC
- [ ] Mobile drawer still works on every page
- [ ] `SideRail` on `/` still tracks the sentinel (it's still there in `HeroSection`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)