### PR TITLE
fix(theme): lift light-mode contrast, swap Bebas for mono in skill list

### DIFF
--- a/src/components/AmbientPlate.astro
+++ b/src/components/AmbientPlate.astro
@@ -53,12 +53,12 @@
     position: absolute;
     inset: 0;
     background-image: radial-gradient(
-      rgba(30, 10, 0, 0.2) 1px,
+      rgba(30, 10, 0, 0.13) 1px,
       transparent 1.3px
     );
     background-size: 3.5px 3.5px;
     mix-blend-mode: multiply;
-    opacity: 0.45;
+    opacity: 0.32;
   }
 
   .ambient-plate__grain {

--- a/src/components/CodeSection.astro
+++ b/src/components/CodeSection.astro
@@ -38,7 +38,7 @@ const supporting = projects.filter((p) => !p.featured);
           <div class="mb-2 border-b border-border-soft pb-2 font-mono text-[11px] uppercase tracking-[2px] text-accent">
             {category}
           </div>
-          <div class="font-heading text-base uppercase tracking-[1px] text-foreground-light">
+          <div class="font-mono text-[13px] uppercase tracking-[1px] text-foreground">
             {items.join(" · ")}
           </div>
         </div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5,8 +5,8 @@
   --color-background: #f5efe2; /* paper */
   --color-background-alt: #ede5d3; /* paperDeep */
   --color-foreground: #1a0f08; /* ink */
-  --color-foreground-light: rgba(50, 35, 25, 0.72); /* inkSoft */
-  --color-muted: rgba(50, 35, 25, 0.5); /* inkMeta */
+  --color-foreground-light: rgba(42, 28, 18, 0.88); /* inkSoft */
+  --color-muted: rgba(42, 28, 18, 0.68); /* inkMeta */
   --color-border: rgba(50, 35, 25, 0.18); /* rule */
   --color-border-soft: rgba(50, 35, 25, 0.1); /* ruleSoft */
   --color-accent: #9a3412; /* rust */


### PR DESCRIPTION
## Summary
- Lift `--color-foreground-light` (0.72 → 0.88) and `--color-muted` (0.5 → 0.68) in the light-mode `@theme` block; dark-mode overrides are untouched.
- Render the Code section's skill values in mono 13px solid foreground instead of Bebas Neue 16px at 72% — Bebas is a condensed display face and isn't legible at body-copy sizes, especially once `AmbientPlate` overlays its dot grid + grain + rust orb via `mix-blend-mode: multiply`.
- Soften the light-mode dot grid on `AmbientPlate` (dot alpha 0.2 → 0.13, layer opacity 0.45 → 0.32); dark-mode rule unchanged.

## Test plan
- [x] `npm run dev`, homepage Code section in light mode: skills render in mono at 13px, body copy + meta rows read cleaner against the textured paper backdrop, rust orb still present but grid is quieter.
- [ ] Toggle to dark mode and confirm the only visible change is the skill list switching from Bebas 16px to mono 13px (token lift and dot-grid softening are scoped to light mode).
- [ ] `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)